### PR TITLE
CPU profiling with direct Pyroscope export to Grafana Cloud

### DIFF
--- a/deploy/configs/profiles.yaml
+++ b/deploy/configs/profiles.yaml
@@ -3,3 +3,8 @@ profiling:
   enabled: true
   sample_rate: 99
   interval: 10s
+  pyroscope:
+    enabled: true
+    endpoint: "https://profiles-prod-001.grafana.net"
+    username: "${GRAFANA_CLOUD_INSTANCE_ID}"
+    password: "${GRAFANA_CLOUD_API_TOKEN}"

--- a/deploy/otel-collector.yaml
+++ b/deploy/otel-collector.yaml
@@ -15,6 +15,8 @@ receivers:
     scrapers:
       load:
       memory:
+  # NOTE: Profiles are pushed directly from olly agent to Grafana Cloud Pyroscope
+  # (otelcol-contrib does not include a pyroscope receiver)
 
 processors:
   batch:

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.23
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0
+	github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7
 	github.com/shirou/gopsutil/v3 v3.24.1
 	go.opentelemetry.io/proto/otlp v1.1.0
 	go.uber.org/zap v1.26.0
+	golang.org/x/net v0.20.0
 	golang.org/x/sys v0.26.0
 	google.golang.org/grpc v1.61.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -24,7 +26,6 @@ require (
 	github.com/tklauser/numcpus v0.7.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240125205218-1f4bbc51befe // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240125205218-1f4bbc51befe // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7 h1:y3N7Bm7Y9/CtpiVkw/ZWj6lSlDF3F74SfKwfTCer72Q=
+github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,9 +122,17 @@ type DiscoveryConfig struct {
 }
 
 type ProfilingConfig struct {
-	Enabled    bool          `yaml:"enabled"`
-	SampleRate int           `yaml:"sample_rate"` // Hz
-	Interval   time.Duration `yaml:"interval"`
+	Enabled    bool            `yaml:"enabled"`
+	SampleRate int             `yaml:"sample_rate"` // Hz
+	Interval   time.Duration   `yaml:"interval"`
+	Pyroscope  PyroscopeConfig `yaml:"pyroscope"`
+}
+
+type PyroscopeConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Endpoint string `yaml:"endpoint"` // e.g., "https://profiles-prod-us-east-0.grafana.net"
+	Username string `yaml:"username"` // Grafana Cloud instance ID (or empty for unauthenticated)
+	Password string `yaml:"password"` // Grafana Cloud API token (or empty for unauthenticated)
 }
 
 type CaptureConfig struct {
@@ -225,6 +233,10 @@ func DefaultConfig() *Config {
 			Enabled:    false,
 			SampleRate: 99,
 			Interval:   10 * time.Second,
+			Pyroscope: PyroscopeConfig{
+				Enabled:  false,
+				Endpoint: "http://localhost:4040",
+			},
 		},
 		Capture: CaptureConfig{
 			Enabled: false,
@@ -295,6 +307,10 @@ func (c *Config) Validate() error {
 
 	if c.Profiling.Enabled && c.Profiling.SampleRate <= 0 {
 		return fmt.Errorf("profiling.sample_rate must be positive")
+	}
+
+	if c.Profiling.Enabled && c.Profiling.Pyroscope.Enabled && c.Profiling.Pyroscope.Endpoint == "" {
+		return fmt.Errorf("profiling.pyroscope.endpoint is required when pyroscope is enabled")
 	}
 
 	return nil

--- a/pkg/export/pyroscope.go
+++ b/pkg/export/pyroscope.go
@@ -1,0 +1,111 @@
+package export
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/mbeema/olly/pkg/config"
+	"github.com/mbeema/olly/pkg/profiling"
+	"go.uber.org/zap"
+)
+
+// PyroscopeExporter pushes pprof profiles to a Pyroscope-compatible HTTP endpoint.
+type PyroscopeExporter struct {
+	endpoint string
+	username string // Basic auth username (Grafana Cloud instance ID)
+	password string // Basic auth password (Grafana Cloud API token)
+	client   *http.Client
+	logger   *zap.Logger
+}
+
+// NewPyroscopeExporter creates a new Pyroscope HTTP exporter.
+func NewPyroscopeExporter(cfg *config.PyroscopeConfig, logger *zap.Logger) *PyroscopeExporter {
+	return &PyroscopeExporter{
+		endpoint: cfg.Endpoint,
+		username: cfg.Username,
+		password: cfg.Password,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger,
+	}
+}
+
+// sanitizeServiceName replaces characters not allowed by Pyroscope.
+var invalidServiceNameChars = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+
+func sanitizeServiceName(name string) string {
+	return invalidServiceNameChars.ReplaceAllString(name, "_")
+}
+
+// ExportProfile sends a gzip'd pprof profile to the Pyroscope receiver.
+func (e *PyroscopeExporter) ExportProfile(ctx context.Context, p *profiling.Profile) error {
+	svcName := sanitizeServiceName(p.ServiceName)
+	url := fmt.Sprintf("%s/ingest?name=%s.cpu&format=pprof&from=%d&until=%d",
+		e.endpoint,
+		svcName,
+		p.Start.Unix(),
+		p.End.Unix(),
+	)
+
+	backoff := initialBackoff
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(p.PProfData))
+		if err != nil {
+			cancel()
+			return fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		if e.username != "" {
+			req.SetBasicAuth(e.username, e.password)
+		}
+
+		resp, err := e.client.Do(req)
+		cancel()
+
+		if err == nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+			err = fmt.Errorf("pyroscope HTTP %d: %s", resp.StatusCode, string(body))
+		}
+
+		if attempt == maxRetries {
+			return fmt.Errorf("pyroscope export failed after %d retries: %w", maxRetries+1, err)
+		}
+
+		e.logger.Warn("pyroscope export failed, retrying",
+			zap.Int("attempt", attempt+1),
+			zap.Duration("backoff", backoff),
+			zap.Error(err),
+		)
+
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		backoff = time.Duration(math.Min(
+			float64(backoff)*backoffFactor,
+			float64(maxBackoff),
+		))
+	}
+
+	return nil
+}
+
+// Shutdown closes the HTTP client.
+func (e *PyroscopeExporter) Shutdown(ctx context.Context) error {
+	e.client.CloseIdleConnections()
+	return nil
+}

--- a/pkg/profiling/pprof.go
+++ b/pkg/profiling/pprof.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package profiling
+
+import (
+	"bytes"
+	"time"
+
+	pprofProfile "github.com/google/pprof/profile"
+)
+
+// buildPProf constructs a gzip-compressed pprof protobuf from aggregated stack samples.
+func buildPProf(pid uint32, stacks map[stackKey]uint64, frames map[stackKey][]uint64,
+	resolver *symbolResolver, start, end time.Time) ([]byte, error) {
+
+	prof := &pprofProfile.Profile{
+		SampleType: []*pprofProfile.ValueType{
+			{Type: "cpu", Unit: "nanoseconds"},
+		},
+		TimeNanos:     start.UnixNano(),
+		DurationNanos: end.Sub(start).Nanoseconds(),
+	}
+
+	// Track unique locations and functions to avoid duplicates
+	locationMap := make(map[uint64]*pprofProfile.Location) // addr → Location
+	functionMap := make(map[string]*pprofProfile.Function) // funcName → Function
+	var locID, funcID uint64
+
+	for key, count := range stacks {
+		ips, ok := frames[key]
+		if !ok {
+			continue
+		}
+
+		var locations []*pprofProfile.Location
+		for _, ip := range ips {
+			if ip == 0 {
+				break
+			}
+
+			loc, exists := locationMap[ip]
+			if !exists {
+				locID++
+				funcName := resolver.Resolve(pid, ip)
+
+				fn, fnExists := functionMap[funcName]
+				if !fnExists {
+					funcID++
+					fn = &pprofProfile.Function{
+						ID:   funcID,
+						Name: funcName,
+					}
+					functionMap[funcName] = fn
+					prof.Function = append(prof.Function, fn)
+				}
+
+				loc = &pprofProfile.Location{
+					ID:      locID,
+					Address: ip,
+					Line: []pprofProfile.Line{
+						{Function: fn},
+					},
+				}
+				locationMap[ip] = loc
+				prof.Location = append(prof.Location, loc)
+			}
+
+			locations = append(locations, loc)
+		}
+
+		if len(locations) > 0 {
+			// Value is sample count * interval (approximate nanoseconds per sample)
+			intervalNs := end.Sub(start).Nanoseconds()
+			totalSamples := uint64(0)
+			for _, c := range stacks {
+				totalSamples += c
+			}
+			valueNs := int64(count)
+			if totalSamples > 0 {
+				valueNs = int64(float64(count) / float64(totalSamples) * float64(intervalNs))
+			}
+
+			prof.Sample = append(prof.Sample, &pprofProfile.Sample{
+				Location: locations,
+				Value:    []int64{valueNs},
+			})
+		}
+	}
+
+	if len(prof.Sample) == 0 {
+		return nil, nil
+	}
+
+	// prof.Write() outputs gzip-compressed protobuf (pprof standard format)
+	var buf bytes.Buffer
+	if err := prof.Write(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/profiling/profiler.go
+++ b/pkg/profiling/profiler.go
@@ -14,7 +14,7 @@ type StackFrame struct {
 	Line     int
 }
 
-// Sample represents a CPU profiling sample.
+// Sample represents a CPU profiling sample (internal use).
 type Sample struct {
 	PID       uint32
 	TID       uint32
@@ -23,11 +23,20 @@ type Sample struct {
 	Count     uint64
 }
 
+// Profile is an aggregated CPU profile ready for export.
+type Profile struct {
+	ServiceName string
+	Start       time.Time
+	End         time.Time
+	PProfData   []byte // gzip'd pprof protobuf
+}
+
 // Profiler is the interface for CPU profiling.
 type Profiler interface {
 	Start(ctx context.Context) error
 	Stop() error
-	OnSample(fn func(*Sample))
+	OnProfile(fn func(*Profile))
+	SetServiceResolver(fn func(pid uint32) string)
 }
 
 // Config holds profiler configuration.

--- a/pkg/profiling/profiler_linux.go
+++ b/pkg/profiling/profiler_linux.go
@@ -4,59 +4,153 @@ package profiling
 
 import (
 	"context"
+	"encoding/binary"
+	"runtime"
 	"sync"
+	"time"
+	"unsafe"
 
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
 
+const (
+	maxStackDepth = 16
+	// Ring buffer: 1 data page + 2^n pages. 8 pages = 32KB per CPU.
+	ringBufferPages = 8
+	pageSize        = 4096
+	ringBufferSize  = (1 + ringBufferPages) * pageSize
+)
+
+// stackKey is a fixed-size array used as a map key for stack aggregation.
+type stackKey [maxStackDepth]uint64
+
+// pidSamples holds aggregated samples for a single PID.
+type pidSamples struct {
+	stacks map[stackKey]uint64   // stack hash → sample count
+	frames map[stackKey][]uint64 // stack hash → raw IPs
+}
+
 // linuxProfiler uses perf_event for CPU profiling on Linux.
 type linuxProfiler struct {
-	cfg       *Config
-	logger    *zap.Logger
+	cfg      *Config
+	logger   *zap.Logger
+	resolver *symbolResolver
+
 	mu        sync.RWMutex
-	callbacks []func(*Sample)
-	wg        sync.WaitGroup
-	stopCh    chan struct{}
-	perfFDs   []int
+	callbacks []func(*Profile)
+
+	perfFDs []int
+	mmaps   [][]byte // mmap'd ring buffers
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+
+	// Aggregation: PID → samples
+	sampleMu sync.Mutex
+	samples  map[uint32]*pidSamples
+
+	// Service name resolution
+	resolveService func(pid uint32) string
+}
+
+// openPerfEvent opens a perf_event fd for CPU profiling on the given CPU.
+// Uses PERF_TYPE_SOFTWARE / PERF_COUNT_SW_CPU_CLOCK for VM compatibility
+// (hardware counters may not be available on EC2/KVM instances).
+func openPerfEvent(sampleRate int, cpu int) (int, error) {
+	attr := &unix.PerfEventAttr{
+		Type:        unix.PERF_TYPE_SOFTWARE,
+		Config:      unix.PERF_COUNT_SW_CPU_CLOCK,
+		Size:        uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
+		Sample:      uint64(sampleRate),
+		Sample_type: unix.PERF_SAMPLE_IP | unix.PERF_SAMPLE_TID | unix.PERF_SAMPLE_CALLCHAIN,
+		Bits:        unix.PerfBitDisabled | unix.PerfBitFreq,
+		Wakeup:      1,
+	}
+
+	fd, err := unix.PerfEventOpen(attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	if err != nil {
+		return -1, err
+	}
+	return fd, nil
 }
 
 func newProfiler(cfg *Config) Profiler {
 	return &linuxProfiler{
-		cfg:    cfg,
-		logger: cfg.Logger,
-		stopCh: make(chan struct{}),
+		cfg:      cfg,
+		logger:   cfg.Logger,
+		resolver: newSymbolResolver(cfg.Logger),
+		stopCh:   make(chan struct{}),
+		samples:  make(map[uint32]*pidSamples),
 	}
 }
 
-func (p *linuxProfiler) OnSample(fn func(*Sample)) {
+func (p *linuxProfiler) OnProfile(fn func(*Profile)) {
 	p.mu.Lock()
 	p.callbacks = append(p.callbacks, fn)
 	p.mu.Unlock()
 }
 
+func (p *linuxProfiler) SetServiceResolver(fn func(pid uint32) string) {
+	p.resolveService = fn
+}
+
 func (p *linuxProfiler) Start(ctx context.Context) error {
-	// Open perf_event for CPU sampling
-	attr := &unix.PerfEventAttr{
-		Type:   unix.PERF_TYPE_SOFTWARE,
-		Config: unix.PERF_COUNT_SW_CPU_CLOCK,
-		Size:   uint32(unsafe_Sizeof_PerfEventAttr()),
-		Bits:   unix.PerfBitFreq,
-		Sample: uint64(p.cfg.SampleRate),
-	}
-	attr.Sample_type = unix.PERF_SAMPLE_IP | unix.PERF_SAMPLE_TID | unix.PERF_SAMPLE_CALLCHAIN
+	numCPUs := runtime.NumCPU()
 
-	// Open on all CPUs for pid -1 (all processes)
-	fd, err := unix.PerfEventOpen(attr, -1, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
-	if err != nil {
-		p.logger.Warn("perf_event_open failed (requires CAP_PERFMON or root)", zap.Error(err))
-		return nil // Non-fatal: profiling is optional
+	// Open perf_event on each CPU for all PIDs (system-wide sampling).
+	for cpu := 0; cpu < numCPUs; cpu++ {
+		fd, err := openPerfEvent(p.cfg.SampleRate, cpu)
+		if err != nil {
+			p.logger.Warn("perf_event_open failed",
+				zap.Int("cpu", cpu),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		// mmap ring buffer
+		buf, err := unix.Mmap(fd, 0, ringBufferSize, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+		if err != nil {
+			p.logger.Warn("mmap failed", zap.Int("cpu", cpu), zap.Error(err))
+			unix.Close(fd)
+			continue
+		}
+
+		// Enable the perf event
+		if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+			p.logger.Warn("PERF_EVENT_IOC_ENABLE failed", zap.Int("cpu", cpu), zap.Error(err))
+			unix.Munmap(buf)
+			unix.Close(fd)
+			continue
+		}
+
+		p.perfFDs = append(p.perfFDs, fd)
+		p.mmaps = append(p.mmaps, buf)
+
+		p.logger.Info("perf_event opened",
+			zap.Int("cpu", cpu),
+			zap.Int("fd", fd),
+		)
 	}
 
-	p.perfFDs = append(p.perfFDs, fd)
+	if len(p.perfFDs) == 0 {
+		p.logger.Warn("no perf_event fds opened (requires CAP_PERFMON or root)")
+		return nil
+	}
+
+	// Start reader goroutine (direct polling, no epoll)
+	p.wg.Add(1)
+	go p.readLoop()
+
+	// Start flush goroutine
+	p.wg.Add(1)
+	go p.flushLoop()
 
 	p.logger.Info("CPU profiler started",
 		zap.Int("sample_rate", p.cfg.SampleRate),
+		zap.Int("cpus", len(p.perfFDs)),
+		zap.Duration("interval", p.cfg.Interval),
 	)
 
 	return nil
@@ -66,13 +160,334 @@ func (p *linuxProfiler) Stop() error {
 	close(p.stopCh)
 	p.wg.Wait()
 
-	for _, fd := range p.perfFDs {
+	// Disable and cleanup
+	for i, fd := range p.perfFDs {
+		unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_DISABLE, 0)
+		if i < len(p.mmaps) {
+			unix.Munmap(p.mmaps[i])
+		}
 		unix.Close(fd)
 	}
 
+	p.logger.Info("CPU profiler stopped")
 	return nil
 }
 
-func unsafe_Sizeof_PerfEventAttr() uintptr {
-	return 120 // sizeof(struct perf_event_attr) on modern kernels
+// readLoop polls the ring buffers directly on a timer and parses perf samples.
+// Direct polling (vs epoll) avoids issues with Go's goroutine scheduler.
+func (p *linuxProfiler) readLoop() {
+	defer p.wg.Done()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Poll every 10ms — low overhead (just reading data_head per CPU per tick)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-ticker.C:
+			for _, buf := range p.mmaps {
+				p.readRingBuffer(buf)
+			}
+		}
+	}
+}
+
+// perfEventMmapPage mirrors the kernel's struct perf_event_mmap_page layout.
+// Used to compute correct field offsets via unsafe.Offsetof.
+// Verified against C offsetof: data_head=1024, data_tail=1032.
+type perfEventMmapPage struct {
+	Version       uint32   // 0
+	CompatVersion uint32   // 4
+	Lock          uint32   // 8
+	Index         uint32   // 12
+	Offset        int64    // 16
+	TimeEnabled   uint64   // 24
+	TimeRunning   uint64   // 32
+	Capabilities  uint64   // 40
+	PmcWidth      uint16   // 48
+	TimeShift     uint16   // 50
+	TimeMult      uint32   // 52
+	TimeOffset    uint64   // 56
+	TimeZero      uint64   // 64
+	Size          uint32   // 72
+	_reserved1    uint32   // 76
+	TimeCycles    uint64   // 80
+	TimeMask      uint64   // 88
+	_reserved     [928]byte // 96..1023 — padding to data_head at 1024
+	DataHead      uint64   // 1024
+	DataTail      uint64   // 1032
+	DataOffset    uint64   // 1040
+	DataSize      uint64   // 1048
+}
+
+// Offsets computed from the Go struct (verified against C offsetof on kernel 6.1).
+var (
+	dataHeadOffset = unsafe.Offsetof(perfEventMmapPage{}.DataHead) // 1024 = 0x400
+	dataTailOffset = unsafe.Offsetof(perfEventMmapPage{}.DataTail) // 1032 = 0x408
+)
+
+const (
+	dataOffset = pageSize
+	dataSize   = ringBufferPages * pageSize
+)
+
+// perf_event_header type constants
+const (
+	PERF_RECORD_SAMPLE = 9
+)
+
+// readRingBuffer reads and parses all available perf records from a ring buffer.
+// Returns the number of PERF_RECORD_SAMPLE records parsed.
+func (p *linuxProfiler) readRingBuffer(buf []byte) int {
+	// Read data_head atomically (kernel updates this concurrently).
+	// Use a memory barrier by reading via atomic load semantics.
+	headPtr := (*uint64)(unsafe.Pointer(&buf[int(dataHeadOffset)]))
+	head := *headPtr // volatile read from mmap'd memory
+
+	tailPtr := (*uint64)(unsafe.Pointer(&buf[int(dataTailOffset)]))
+	tail := *tailPtr
+
+	if head == tail {
+		return 0 // No new data
+	}
+
+	data := buf[dataOffset:]
+	count := 0
+
+	for tail < head {
+		offset := tail % uint64(dataSize)
+
+		// Read perf_event_header (type u32, misc u16, size u16)
+		if offset+8 > uint64(dataSize) {
+			// Header wraps around — skip to avoid complexity
+			tail += 8
+			continue
+		}
+
+		eventType := binary.LittleEndian.Uint32(data[offset:])
+		eventSize := binary.LittleEndian.Uint16(data[offset+6:])
+
+		if eventSize == 0 || eventSize > 4096 {
+			// Corrupt record, reset
+			break
+		}
+
+		if eventType == PERF_RECORD_SAMPLE {
+			p.parseSample(data, offset+8, uint64(eventSize)-8)
+			count++
+		}
+
+		tail += uint64(eventSize)
+	}
+
+	// Update data_tail to acknowledge consumed data (write barrier)
+	*tailPtr = tail
+	return count
+}
+
+// parseSample extracts IP, PID, TID, and callchain from a PERF_RECORD_SAMPLE.
+// Layout for PERF_SAMPLE_IP | PERF_SAMPLE_TID | PERF_SAMPLE_CALLCHAIN:
+//
+//	u64 ip
+//	u32 pid, tid
+//	u64 nr (callchain length)
+//	u64 ips[nr]
+func (p *linuxProfiler) parseSample(data []byte, offset, remaining uint64) {
+	if remaining < 16 { // ip(8) + pid/tid(8) minimum
+		return
+	}
+
+	// Read with ring buffer wrapping
+	readU64 := func(off uint64) uint64 {
+		pos := off % uint64(dataSize)
+		if pos+8 <= uint64(dataSize) {
+			return binary.LittleEndian.Uint64(data[pos:])
+		}
+		// Handle wrap-around
+		var tmp [8]byte
+		for i := 0; i < 8; i++ {
+			tmp[i] = data[(pos+uint64(i))%uint64(dataSize)]
+		}
+		return binary.LittleEndian.Uint64(tmp[:])
+	}
+
+	readU32 := func(off uint64) uint32 {
+		pos := off % uint64(dataSize)
+		if pos+4 <= uint64(dataSize) {
+			return binary.LittleEndian.Uint32(data[pos:])
+		}
+		var tmp [4]byte
+		for i := 0; i < 4; i++ {
+			tmp[i] = data[(pos+uint64(i))%uint64(dataSize)]
+		}
+		return binary.LittleEndian.Uint32(tmp[:])
+	}
+
+	ip := readU64(offset)
+	pid := readU32(offset + 8)
+	tid := readU32(offset + 12)
+	_ = tid // Available but unused for now
+
+	// Build stack key starting with IP
+	var key stackKey
+	var ips []uint64
+	key[0] = ip
+	ips = append(ips, ip)
+
+	// Read callchain if available
+	if remaining >= 24 { // ip + pid/tid + nr
+		nr := readU64(offset + 16)
+		if nr > maxStackDepth {
+			nr = maxStackDepth
+		}
+
+		chainOffset := offset + 24
+		for i := uint64(0); i < nr && i < maxStackDepth-1; i++ {
+			if 24+8*(i+1) > remaining {
+				break
+			}
+			chainIP := readU64(chainOffset + i*8)
+			// Skip kernel/user markers (values like 0xffffffff...)
+			if chainIP > 0xf000000000000000 {
+				continue
+			}
+			if len(ips) < maxStackDepth {
+				key[len(ips)] = chainIP
+				ips = append(ips, chainIP)
+			}
+		}
+	}
+
+	// Aggregate
+	p.sampleMu.Lock()
+	ps, ok := p.samples[pid]
+	if !ok {
+		ps = &pidSamples{
+			stacks: make(map[stackKey]uint64),
+			frames: make(map[stackKey][]uint64),
+		}
+		p.samples[pid] = ps
+	}
+	ps.stacks[key]++
+	if _, exists := ps.frames[key]; !exists {
+		ipsCopy := make([]uint64, len(ips))
+		copy(ipsCopy, ips)
+		ps.frames[key] = ipsCopy
+	}
+	p.sampleMu.Unlock()
+}
+
+// flushLoop periodically snapshots, resolves, and emits profiles.
+func (p *linuxProfiler) flushLoop() {
+	defer p.wg.Done()
+
+	interval := p.cfg.Interval
+	if interval == 0 {
+		interval = 10 * time.Second
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	flushStart := time.Now()
+
+	for {
+		select {
+		case <-ticker.C:
+			now := time.Now()
+			p.flush(flushStart, now)
+			flushStart = now
+
+			// Periodic symbol cache cleanup
+			p.resolver.cleanup()
+
+		case <-p.stopCh:
+			// Final flush
+			p.flush(flushStart, time.Now())
+			return
+		}
+	}
+}
+
+func (p *linuxProfiler) flush(start, end time.Time) {
+	// Snapshot and reset aggregation
+	p.sampleMu.Lock()
+	snapshot := p.samples
+	p.samples = make(map[uint32]*pidSamples)
+	p.sampleMu.Unlock()
+
+	if len(snapshot) == 0 {
+		return
+	}
+
+	// Group by service name
+	type serviceData struct {
+		stacks map[stackKey]uint64
+		frames map[stackKey][]uint64
+		pid    uint32 // representative PID for symbol resolution
+	}
+	byService := make(map[string]*serviceData)
+
+	for pid, ps := range snapshot {
+		serviceName := "unknown"
+		if p.resolveService != nil {
+			serviceName = p.resolveService(pid)
+		}
+
+		sd, ok := byService[serviceName]
+		if !ok {
+			sd = &serviceData{
+				stacks: make(map[stackKey]uint64),
+				frames: make(map[stackKey][]uint64),
+				pid:    pid,
+			}
+			byService[serviceName] = sd
+		}
+
+		for key, count := range ps.stacks {
+			sd.stacks[key] += count
+		}
+		for key, ips := range ps.frames {
+			if _, exists := sd.frames[key]; !exists {
+				sd.frames[key] = ips
+			}
+		}
+	}
+
+	// Build and emit profiles per service
+	p.mu.RLock()
+	callbacks := make([]func(*Profile), len(p.callbacks))
+	copy(callbacks, p.callbacks)
+	p.mu.RUnlock()
+
+	for serviceName, sd := range byService {
+		pprofData, err := buildPProf(sd.pid, sd.stacks, sd.frames, p.resolver, start, end)
+		if err != nil {
+			p.logger.Warn("pprof build error", zap.String("service", serviceName), zap.Error(err))
+			continue
+		}
+		if pprofData == nil {
+			continue
+		}
+
+		profile := &Profile{
+			ServiceName: serviceName,
+			Start:       start,
+			End:         end,
+			PProfData:   pprofData,
+		}
+
+		for _, cb := range callbacks {
+			cb(profile)
+		}
+	}
+
+	p.logger.Debug("profiles flushed",
+		zap.Int("services", len(byService)),
+		zap.Int("pids", len(snapshot)),
+	)
 }

--- a/pkg/profiling/profiler_stub.go
+++ b/pkg/profiling/profiler_stub.go
@@ -26,6 +26,10 @@ func (p *stubProfiler) Stop() error {
 	return nil
 }
 
-func (p *stubProfiler) OnSample(fn func(*Sample)) {
+func (p *stubProfiler) OnProfile(fn func(*Profile)) {
+	// No-op
+}
+
+func (p *stubProfiler) SetServiceResolver(fn func(pid uint32) string) {
 	// No-op
 }

--- a/pkg/profiling/symbols.go
+++ b/pkg/profiling/symbols.go
@@ -1,0 +1,311 @@
+//go:build linux
+
+package profiling
+
+import (
+	"bufio"
+	"debug/elf"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	maxELFCacheSize = 256
+	mapsCacheTTL    = 60 * time.Second
+)
+
+type symbolResolver struct {
+	mu     sync.RWMutex
+	cache  map[string]*elfSymbols // binary path → symbol table
+	maps   map[uint32]*pidMaps   // PID → parsed /proc/pid/maps
+	logger *zap.Logger
+}
+
+type pidMaps struct {
+	mappings []*mapping
+	loaded   time.Time
+}
+
+type mapping struct {
+	StartAddr uint64
+	EndAddr   uint64
+	Offset    uint64
+	File      string
+}
+
+type elfSymbols struct {
+	symbols []elfSym // sorted by addr for binary search
+	loaded  time.Time
+}
+
+type elfSym struct {
+	Addr uint64
+	Size uint64
+	Name string
+}
+
+func newSymbolResolver(logger *zap.Logger) *symbolResolver {
+	return &symbolResolver{
+		cache:  make(map[string]*elfSymbols),
+		maps:   make(map[uint32]*pidMaps),
+		logger: logger,
+	}
+}
+
+// Resolve translates a PID + instruction pointer address to a function name.
+func (r *symbolResolver) Resolve(pid uint32, addr uint64) (funcName string) {
+	mappings := r.getMappings(pid)
+	if mappings == nil {
+		return fmt.Sprintf("0x%x", addr)
+	}
+
+	// Find the mapping containing this address
+	for _, m := range mappings {
+		if addr >= m.StartAddr && addr < m.EndAddr {
+			if m.File == "" || m.File == "[vdso]" || m.File == "[vsyscall]" {
+				return fmt.Sprintf("0x%x", addr)
+			}
+
+			syms := r.getELFSymbols(m.File)
+			if syms == nil {
+				return fmt.Sprintf("0x%x", addr)
+			}
+
+			// Calculate file offset: addr - mapping start + file offset
+			fileAddr := addr - m.StartAddr + m.Offset
+			name := findSymbol(syms.symbols, fileAddr)
+			if name != "" {
+				return name
+			}
+
+			// Try with raw address (for non-PIE executables)
+			name = findSymbol(syms.symbols, addr)
+			if name != "" {
+				return name
+			}
+
+			return fmt.Sprintf("0x%x", addr)
+		}
+	}
+
+	return fmt.Sprintf("0x%x", addr)
+}
+
+func (r *symbolResolver) getMappings(pid uint32) []*mapping {
+	r.mu.RLock()
+	pm, ok := r.maps[pid]
+	r.mu.RUnlock()
+
+	if ok && time.Since(pm.loaded) < mapsCacheTTL {
+		return pm.mappings
+	}
+
+	mappings := r.loadMaps(pid)
+	if mappings == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	r.maps[pid] = &pidMaps{
+		mappings: mappings,
+		loaded:   time.Now(),
+	}
+	r.mu.Unlock()
+
+	return mappings
+}
+
+func (r *symbolResolver) loadMaps(pid uint32) []*mapping {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/maps", pid))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var mappings []*mapping
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		m := parseMapsLine(line)
+		if m != nil {
+			mappings = append(mappings, m)
+		}
+	}
+
+	return mappings
+}
+
+// parseMapsLine parses a line from /proc/pid/maps.
+// Format: start-end perms offset dev inode pathname
+func parseMapsLine(line string) *mapping {
+	fields := strings.Fields(line)
+	if len(fields) < 5 {
+		return nil
+	}
+
+	// Only care about executable mappings
+	if len(fields[1]) < 3 || fields[1][2] != 'x' {
+		return nil
+	}
+
+	addrs := strings.SplitN(fields[0], "-", 2)
+	if len(addrs) != 2 {
+		return nil
+	}
+
+	start, err := strconv.ParseUint(addrs[0], 16, 64)
+	if err != nil {
+		return nil
+	}
+	end, err := strconv.ParseUint(addrs[1], 16, 64)
+	if err != nil {
+		return nil
+	}
+	offset, err := strconv.ParseUint(fields[2], 16, 64)
+	if err != nil {
+		return nil
+	}
+
+	file := ""
+	if len(fields) >= 6 {
+		file = fields[5]
+	}
+
+	return &mapping{
+		StartAddr: start,
+		EndAddr:   end,
+		Offset:    offset,
+		File:      file,
+	}
+}
+
+func (r *symbolResolver) getELFSymbols(path string) *elfSymbols {
+	r.mu.RLock()
+	syms, ok := r.cache[path]
+	r.mu.RUnlock()
+
+	if ok {
+		return syms
+	}
+
+	syms = r.loadELF(path)
+	if syms == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	// Evict oldest if cache is full
+	if len(r.cache) >= maxELFCacheSize {
+		var oldestKey string
+		var oldestTime time.Time
+		for k, v := range r.cache {
+			if oldestKey == "" || v.loaded.Before(oldestTime) {
+				oldestKey = k
+				oldestTime = v.loaded
+			}
+		}
+		if oldestKey != "" {
+			delete(r.cache, oldestKey)
+		}
+	}
+	r.cache[path] = syms
+	r.mu.Unlock()
+
+	return syms
+}
+
+func (r *symbolResolver) loadELF(path string) *elfSymbols {
+	f, err := elf.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var allSyms []elfSym
+
+	// Read .symtab
+	symbols, err := f.Symbols()
+	if err == nil {
+		for _, s := range symbols {
+			if s.Value != 0 && s.Name != "" && elf.ST_TYPE(s.Info) == elf.STT_FUNC {
+				allSyms = append(allSyms, elfSym{
+					Addr: s.Value,
+					Size: s.Size,
+					Name: s.Name,
+				})
+			}
+		}
+	}
+
+	// Read .dynsym
+	dynSyms, err := f.DynamicSymbols()
+	if err == nil {
+		for _, s := range dynSyms {
+			if s.Value != 0 && s.Name != "" && elf.ST_TYPE(s.Info) == elf.STT_FUNC {
+				allSyms = append(allSyms, elfSym{
+					Addr: s.Value,
+					Size: s.Size,
+					Name: s.Name,
+				})
+			}
+		}
+	}
+
+	if len(allSyms) == 0 {
+		return nil
+	}
+
+	// Sort by address for binary search
+	sort.Slice(allSyms, func(i, j int) bool {
+		return allSyms[i].Addr < allSyms[j].Addr
+	})
+
+	return &elfSymbols{
+		symbols: allSyms,
+		loaded:  time.Now(),
+	}
+}
+
+// findSymbol does a binary search for the function containing addr.
+func findSymbol(symbols []elfSym, addr uint64) string {
+	if len(symbols) == 0 {
+		return ""
+	}
+
+	// Binary search for the last symbol with Addr <= addr
+	idx := sort.Search(len(symbols), func(i int) bool {
+		return symbols[i].Addr > addr
+	})
+
+	if idx == 0 {
+		return ""
+	}
+
+	sym := symbols[idx-1]
+	// If the symbol has a size, check that addr falls within it
+	if sym.Size > 0 && addr >= sym.Addr+sym.Size {
+		return ""
+	}
+
+	return sym.Name
+}
+
+// cleanup removes stale PID entries from the maps cache.
+func (r *symbolResolver) cleanup() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	for pid, pm := range r.maps {
+		if now.Sub(pm.loaded) > 2*mapsCacheTTL {
+			delete(r.maps, pid)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Full CPU profiling pipeline: perf_event ring buffer sampling (99Hz, system-wide) → symbol resolution (ELF + /proc/pid/maps) → pprof building → direct HTTP push to Grafana Cloud Pyroscope with Basic Auth
- Profiles bypass OTEL Collector entirely (otelcol-contrib has no pyroscope receiver, even in v0.145.0)
- Service name sanitization for kernel workers (kworker/0:1-events → kworker_0_1-events)
- 13 files changed, 1185 insertions

## Key fixes
- perf_event_mmap_page `_reserved` padding: 928 bytes (not 912) — data_head lives at offset 1024
- Direct timer polling instead of epoll (Go scheduler compatibility)
- Single gzip: `prof.Write()` already outputs gzip'd protobuf — DO NOT double-gzip

## Test plan
- [x] `go build ./...` passes
- [x] Verified on EC2 (t3.small, Amazon Linux 2023): ~1980 samples/10s at 99Hz on 2 CPUs
- [x] Profiles flowing to Grafana Cloud Pyroscope (0 errors, 0 retries)
- [x] OTEL Collector traces/metrics/logs pipeline unaffected