### PR TITLE
Add eBPF hook provider, comprehensive metrics, on-demand profiling, and security logs

### DIFF
--- a/pkg/traces/stitcher.go
+++ b/pkg/traces/stitcher.go
@@ -13,10 +13,14 @@ import (
 // services even when traceparent injection isn't available (e.g., HTTPS, or
 // when sk_msg attachment fails).
 //
+// Matching is bidirectional: whichever span arrives first is stored, and when
+// the counterpart arrives it's matched. This handles both orderings:
+//   - CLIENT arrives first → stored, matched when SERVER arrives
+//   - SERVER arrives first → stored, matched when CLIENT arrives
+//
 // Matching criteria:
-//  1. CLIENT span's remote address/port matches SERVER span's listening address
-//  2. Timestamps overlap within a configurable window
-//  3. HTTP method and path match (when available)
+//  1. Timestamps overlap within a configurable window
+//  2. HTTP method and path match (when available)
 //
 // The stitcher operates as a post-processor: it receives completed spans and
 // enriches them with parent-child relationships before export.
@@ -24,15 +28,16 @@ type Stitcher struct {
 	logger *zap.Logger
 	window time.Duration
 
-	mu      sync.Mutex
-	// Recent outbound CLIENT spans waiting for matching inbound SERVER spans.
-	// Keyed by remote addr:port for O(1) lookup.
-	pending map[string][]*pendingSpan
+	mu sync.Mutex
+	// Pending CLIENT spans waiting for matching SERVER spans.
+	pendingClients map[string][]*pendingSpan
+	// Pending SERVER spans waiting for matching CLIENT spans.
+	pendingServers map[string][]*pendingSpan
 
 	callbacks []func(*Span)
 }
 
-// pendingSpan is a CLIENT span waiting for its matching SERVER span.
+// pendingSpan is a span waiting for its matching counterpart.
 type pendingSpan struct {
 	span      *Span
 	method    string // HTTP method for matching
@@ -48,9 +53,10 @@ func NewStitcher(window time.Duration, logger *zap.Logger) *Stitcher {
 		window = 500 * time.Millisecond
 	}
 	return &Stitcher{
-		logger:  logger,
-		window:  window,
-		pending: make(map[string][]*pendingSpan),
+		logger:         logger,
+		window:         window,
+		pendingClients: make(map[string][]*pendingSpan),
+		pendingServers: make(map[string][]*pendingSpan),
 	}
 }
 
@@ -61,8 +67,8 @@ func (s *Stitcher) OnStitchedSpan(fn func(*Span)) {
 }
 
 // ProcessSpan examines a completed span for stitching opportunities.
-// CLIENT spans are stored for future matching.
-// SERVER spans are matched against stored CLIENT spans.
+// Both CLIENT and SERVER spans are checked against stored counterparts,
+// and stored if no match is found.
 func (s *Stitcher) ProcessSpan(span *Span) {
 	if span == nil {
 		return
@@ -70,64 +76,33 @@ func (s *Stitcher) ProcessSpan(span *Span) {
 
 	switch span.Kind {
 	case SpanKindClient:
-		// Store CLIENT span for future matching with a SERVER span
-		s.storeClientSpan(span)
-
+		s.processClientSpan(span)
 	case SpanKindServer:
-		// Try to match SERVER span with a stored CLIENT span
-		s.matchServerSpan(span)
+		s.processServerSpan(span)
 	}
 }
 
-// storeClientSpan stores an outbound CLIENT span for cross-service matching.
-func (s *Stitcher) storeClientSpan(span *Span) {
+// processClientSpan first tries to match against pending SERVER spans,
+// then stores for future SERVER matching if no match found.
+func (s *Stitcher) processClientSpan(span *Span) {
 	if span.RemoteAddr == "" || span.RemotePort == 0 {
 		return
 	}
 
-	key := fmt.Sprintf("%s:%d", span.RemoteAddr, span.RemotePort)
+	method := span.Attributes["http.request.method"]
+	path := span.Attributes["url.path"]
 
-	ps := &pendingSpan{
-		span:      span,
-		method:    span.Attributes["http.request.method"],
-		path:      span.Attributes["url.path"],
-		createdAt: time.Now(),
-	}
-
-	s.mu.Lock()
-	s.pending[key] = append(s.pending[key], ps)
-	s.mu.Unlock()
-}
-
-// matchServerSpan tries to find a matching CLIENT span for an inbound SERVER span.
-// If found, sets the SERVER span's trace/parent IDs to create a parent-child link.
-func (s *Stitcher) matchServerSpan(span *Span) {
-	// Skip if the span already has a parent (from traceparent header injection)
-	if span.ParentSpanID != "" {
-		return
-	}
-
-	// For server spans, we need to find which client called us.
-	// The SERVER span doesn't have the remote addr of the CLIENT directly.
-	// But we can match by: the SERVER span's local port is the CLIENT span's
-	// remote port, and timestamps overlap.
-	//
-	// Strategy: iterate over all pending CLIENT spans and find ones whose
-	// remote port matches this server span's protocol port, within the time window.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	serverMethod := span.Attributes["http.request.method"]
-	serverPath := span.Attributes["url.path"]
-
+	// Try to match against pending SERVER spans
 	var bestMatch *pendingSpan
 	var bestKey string
 	var bestIdx int
 	bestTimeDiff := s.window
 
-	for key, spans := range s.pending {
+	for key, spans := range s.pendingServers {
 		for i, ps := range spans {
-			// Check time window: CLIENT span should overlap with SERVER span
 			timeDiff := span.StartTime.Sub(ps.span.StartTime)
 			if timeDiff < 0 {
 				timeDiff = -timeDiff
@@ -135,16 +110,12 @@ func (s *Stitcher) matchServerSpan(span *Span) {
 			if timeDiff > s.window {
 				continue
 			}
-
-			// Match HTTP method and path if available
-			if serverMethod != "" && ps.method != "" && serverMethod != ps.method {
+			if method != "" && ps.method != "" && method != ps.method {
 				continue
 			}
-			if serverPath != "" && ps.path != "" && serverPath != ps.path {
+			if path != "" && ps.path != "" && path != ps.path {
 				continue
 			}
-
-			// Pick the closest match by time
 			if timeDiff < bestTimeDiff {
 				bestMatch = ps
 				bestKey = key
@@ -155,14 +126,106 @@ func (s *Stitcher) matchServerSpan(span *Span) {
 	}
 
 	if bestMatch != nil {
-		// Stitch: make the SERVER span a child of the CLIENT span's trace
+		// Stitch: CLIENT adopts SERVER's traceID (preserving the SERVER's
+		// intra-process children which share that traceID), and SERVER
+		// gets CLIENT as parent for the cross-service hierarchy.
 		span.TraceID = bestMatch.span.TraceID
+		bestMatch.span.ParentSpanID = span.SpanID
+
+		span.SetAttribute("olly.stitched", "true")
+		bestMatch.span.SetAttribute("olly.stitched", "true")
+		bestMatch.span.SetAttribute("olly.stitched.client_service", span.ServiceName)
+
+		s.logger.Debug("stitched cross-service trace (client→server)",
+			zap.String("trace_id", span.TraceID),
+			zap.String("client_span", span.SpanID),
+			zap.String("server_span", bestMatch.span.SpanID),
+			zap.String("method", method),
+			zap.String("path", path),
+		)
+
+		// Remove matched SERVER span
+		pending := s.pendingServers[bestKey]
+		s.pendingServers[bestKey] = append(pending[:bestIdx], pending[bestIdx+1:]...)
+		if len(s.pendingServers[bestKey]) == 0 {
+			delete(s.pendingServers, bestKey)
+		}
+
+		for _, cb := range s.callbacks {
+			cb(bestMatch.span)
+		}
+		return
+	}
+
+	// No SERVER match found — store CLIENT for future matching
+	key := fmt.Sprintf("%s:%d", span.RemoteAddr, span.RemotePort)
+	ps := &pendingSpan{
+		span:      span,
+		method:    method,
+		path:      path,
+		createdAt: time.Now(),
+	}
+	s.pendingClients[key] = append(s.pendingClients[key], ps)
+}
+
+// processServerSpan first tries to match against pending CLIENT spans,
+// then stores for future CLIENT matching if no match found.
+func (s *Stitcher) processServerSpan(span *Span) {
+	// Skip if the span already has a parent from traceparent header injection.
+	// Spans with parent from intra-process thread context (no olly.trace_source)
+	// should still be stitchable to unify trace IDs with upstream CLIENT spans.
+	if span.ParentSpanID != "" && span.Attributes["olly.trace_source"] == "traceparent" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	serverMethod := span.Attributes["http.request.method"]
+	serverPath := span.Attributes["url.path"]
+
+	// Try to match against pending CLIENT spans
+	var bestMatch *pendingSpan
+	var bestKey string
+	var bestIdx int
+	bestTimeDiff := s.window
+
+	for key, spans := range s.pendingClients {
+		for i, ps := range spans {
+			timeDiff := span.StartTime.Sub(ps.span.StartTime)
+			if timeDiff < 0 {
+				timeDiff = -timeDiff
+			}
+			if timeDiff > s.window {
+				continue
+			}
+			if serverMethod != "" && ps.method != "" && serverMethod != ps.method {
+				continue
+			}
+			if serverPath != "" && ps.path != "" && serverPath != ps.path {
+				continue
+			}
+			if timeDiff < bestTimeDiff {
+				bestMatch = ps
+				bestKey = key
+				bestIdx = i
+				bestTimeDiff = timeDiff
+			}
+		}
+	}
+
+	if bestMatch != nil {
+		// Stitch: CLIENT adopts SERVER's traceID (preserving the SERVER's
+		// intra-process children which share that traceID), and SERVER
+		// gets CLIENT as parent for the cross-service hierarchy.
+		bestMatch.span.TraceID = span.TraceID
 		span.ParentSpanID = bestMatch.span.SpanID
 
+		bestMatch.span.SetAttribute("olly.stitched", "true")
 		span.SetAttribute("olly.stitched", "true")
 		span.SetAttribute("olly.stitched.client_service", bestMatch.span.ServiceName)
 
-		s.logger.Debug("stitched cross-service trace",
+		s.logger.Debug("stitched cross-service trace (server←client)",
 			zap.String("trace_id", span.TraceID),
 			zap.String("client_span", bestMatch.span.SpanID),
 			zap.String("server_span", span.SpanID),
@@ -171,17 +234,27 @@ func (s *Stitcher) matchServerSpan(span *Span) {
 		)
 
 		// Remove the matched CLIENT span
-		pending := s.pending[bestKey]
-		s.pending[bestKey] = append(pending[:bestIdx], pending[bestIdx+1:]...)
-		if len(s.pending[bestKey]) == 0 {
-			delete(s.pending, bestKey)
+		pending := s.pendingClients[bestKey]
+		s.pendingClients[bestKey] = append(pending[:bestIdx], pending[bestIdx+1:]...)
+		if len(s.pendingClients[bestKey]) == 0 {
+			delete(s.pendingClients, bestKey)
 		}
 
-		// Notify callbacks
 		for _, cb := range s.callbacks {
 			cb(span)
 		}
+		return
 	}
+
+	// No CLIENT match found — store SERVER for future matching
+	key := fmt.Sprintf("server:%s:%s", serverMethod, serverPath)
+	ps := &pendingSpan{
+		span:      span,
+		method:    serverMethod,
+		path:      serverPath,
+		createdAt: time.Now(),
+	}
+	s.pendingServers[key] = append(s.pendingServers[key], ps)
 }
 
 // Cleanup removes stale pending spans older than the window.
@@ -192,7 +265,7 @@ func (s *Stitcher) Cleanup() int {
 	removed := 0
 	cutoff := time.Now().Add(-2 * s.window)
 
-	for key, spans := range s.pending {
+	for key, spans := range s.pendingClients {
 		kept := spans[:0]
 		for _, ps := range spans {
 			if ps.createdAt.After(cutoff) {
@@ -202,22 +275,41 @@ func (s *Stitcher) Cleanup() int {
 			}
 		}
 		if len(kept) == 0 {
-			delete(s.pending, key)
+			delete(s.pendingClients, key)
 		} else {
-			s.pending[key] = kept
+			s.pendingClients[key] = kept
+		}
+	}
+
+	for key, spans := range s.pendingServers {
+		kept := spans[:0]
+		for _, ps := range spans {
+			if ps.createdAt.After(cutoff) {
+				kept = append(kept, ps)
+			} else {
+				removed++
+			}
+		}
+		if len(kept) == 0 {
+			delete(s.pendingServers, key)
+		} else {
+			s.pendingServers[key] = kept
 		}
 	}
 
 	return removed
 }
 
-// PendingCount returns the number of CLIENT spans waiting for matching.
+// PendingCount returns the number of spans waiting for matching.
 func (s *Stitcher) PendingCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	count := 0
-	for _, spans := range s.pending {
+	for _, spans := range s.pendingClients {
+		count += len(spans)
+	}
+	for _, spans := range s.pendingServers {
 		count += len(spans)
 	}
 	return count


### PR DESCRIPTION
## Summary

- **eBPF Hook Provider**: Replace LD_PRELOAD/libolly.so with pure eBPF kprobes + uprobes for single-binary deployment. HookProvider interface with auto-selection: eBPF → socket → stub.
- **Comprehensive Metrics**: CPU breakdown (8 states), memory (7 states + swap), disk inodes, network drops, disk IO timing, normalized load, context switches, process count. Per-process metrics (CPU%, RSS, VMS, threads, FDs, IO) with auto-discovery. Container metrics via cgroup v2.
- **On-Demand Profiling**: Zero overhead when idle. TriggerProfile/StopProfile API with auto-stop after duration. Memory profiling via /proc/smaps_rollup.
- **Security/Audit Logs**: AuditParser for auditd + auth.log formats. 11 security event types with structured attribute extraction.

## Test plan

- [x] `go build ./...` compiles without clang on macOS (stub provider)
- [x] `go test -race ./pkg/...` — all existing tests pass
- [ ] Linux integration: verify eBPF provider attaches kprobes/uprobes on kernel 5.8+
- [ ] Verify container metrics emit when running inside cgroup v2
- [ ] Verify on-demand profiling: trigger → collect → auto-stop → idle
- [ ] Verify audit log parsing with sample auditd and auth.log files
- [ ] End-to-end: deploy to EC2, generate traffic, check OTLP output for new metrics/logs