### PR TITLE
Add BSL 1.1 license and copyright headers to all source files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,36 @@
+Business Source License 1.1
+
+Licensor: Madhukar Beema
+Licensed Work: Olly Agent
+Change Date: Four years from each release date
+Change License: Apache License, Version 2.0
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create
+derivative works, redistribute, and make non-production use of the
+Licensed Work.
+
+Production use of the Licensed Work is only permitted when your use
+does not include offering the Licensed Work to third parties on a
+hosted or embedded basis in a manner that competes with the Licensor
+paid products.
+
+For purposes of this license, a competitive offering means a product
+or service that is substantially similar to any of the Licensor paid
+products and is made available as a managed service, hosted service,
+or as part of a service offering.
+
+If your use of the Licensed Work does not constitute a competitive
+offering, you may use the Licensed Work in production under the terms
+of this license.
+
+Effective on the Change Date, the Licensor hereby grants you rights
+under the terms of the Change License, and the rights granted under
+this license terminate.
+
+Notice
+
+Copyright 2024-2026 Madhukar Beema. All rights reserved.
+
+Business Source License 1.1 as published at mariadb.com/bsl11

--- a/cmd/olly/main.go
+++ b/cmd/olly/main.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package main
 
 import (

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package agent
 
 import (

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package agent
 
 import (

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package capture
 
 import (

--- a/pkg/capture/capture_darwin.go
+++ b/pkg/capture/capture_darwin.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build darwin
 
 package capture

--- a/pkg/capture/capture_linux.go
+++ b/pkg/capture/capture_linux.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build linux
 
 package capture

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package config
 
 import (

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package config
 
 import "testing"

--- a/pkg/config/watcher.go
+++ b/pkg/config/watcher.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package config
 
 import (

--- a/pkg/conntrack/tracker.go
+++ b/pkg/conntrack/tracker.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package conntrack
 
 import (

--- a/pkg/conntrack/tracker_test.go
+++ b/pkg/conntrack/tracker_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package conntrack
 
 import (

--- a/pkg/correlation/engine.go
+++ b/pkg/correlation/engine.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package correlation
 
 import (

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package discovery
 
 import (

--- a/pkg/export/manager.go
+++ b/pkg/export/manager.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package export
 
 import (

--- a/pkg/export/otlp.go
+++ b/pkg/export/otlp.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package export
 
 import (

--- a/pkg/export/pyroscope.go
+++ b/pkg/export/pyroscope.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package export
 
 import (

--- a/pkg/export/stdout.go
+++ b/pkg/export/stdout.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package export
 
 import (

--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package health
 
 import (

--- a/pkg/health/server_test.go
+++ b/pkg/health/server_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package health
 
 import (

--- a/pkg/health/stats.go
+++ b/pkg/health/stats.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package health
 
 import (

--- a/pkg/hook/control.go
+++ b/pkg/hook/control.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package hook
 
 import (

--- a/pkg/hook/ebpf/detect.go
+++ b/pkg/hook/ebpf/detect.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package ebpf
 
 import "fmt"

--- a/pkg/hook/ebpf/detect_linux.go
+++ b/pkg/hook/ebpf/detect_linux.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build linux
 
 package ebpf

--- a/pkg/hook/ebpf/detect_other.go
+++ b/pkg/hook/ebpf/detect_other.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build !linux
 
 package ebpf

--- a/pkg/hook/ebpf/gen.go
+++ b/pkg/hook/ebpf/gen.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package ebpf
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -target amd64 -cflags "-O2 -g -Wall -Werror -D__TARGET_ARCH_x86" olly bpf/olly.bpf.c -- -Ibpf/headers -Ibpf

--- a/pkg/hook/ebpf/loader.go
+++ b/pkg/hook/ebpf/loader.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build linux
 
 package ebpf

--- a/pkg/hook/ebpf/provider_linux.go
+++ b/pkg/hook/ebpf/provider_linux.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package ebpf
 
 import (

--- a/pkg/hook/ebpf/provider_other.go
+++ b/pkg/hook/ebpf/provider_other.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build !linux
 
 package ebpf

--- a/pkg/hook/ebpf/ringbuf.go
+++ b/pkg/hook/ebpf/ringbuf.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build linux
 
 package ebpf

--- a/pkg/hook/ebpf/ssl.go
+++ b/pkg/hook/ebpf/ssl.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build linux
 
 package ebpf

--- a/pkg/hook/ebpf/stub.go
+++ b/pkg/hook/ebpf/stub.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package ebpf
 
 import (

--- a/pkg/hook/injector.go
+++ b/pkg/hook/injector.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package hook
 
 import (

--- a/pkg/hook/manager.go
+++ b/pkg/hook/manager.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package hook
 
 import (

--- a/pkg/hook/manager_test.go
+++ b/pkg/hook/manager_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package hook
 
 import (

--- a/pkg/hook/protocol.go
+++ b/pkg/hook/protocol.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package hook
 
 import (

--- a/pkg/hook/protocol_test.go
+++ b/pkg/hook/protocol_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package hook
 
 import (

--- a/pkg/hook/provider.go
+++ b/pkg/hook/provider.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package hook
 
 import "context"

--- a/pkg/logs/audit.go
+++ b/pkg/logs/audit.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package logs
 
 import (

--- a/pkg/logs/collector.go
+++ b/pkg/logs/collector.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package logs
 
 import (

--- a/pkg/logs/journald.go
+++ b/pkg/logs/journald.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package logs
 
 import (

--- a/pkg/logs/parser.go
+++ b/pkg/logs/parser.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package logs
 
 import (

--- a/pkg/logs/parser_test.go
+++ b/pkg/logs/parser_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package logs
 
 import (

--- a/pkg/logs/tailer.go
+++ b/pkg/logs/tailer.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package logs
 
 import (

--- a/pkg/logs/tailer_unix.go
+++ b/pkg/logs/tailer_unix.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build !windows
 
 package logs

--- a/pkg/logs/tailer_windows.go
+++ b/pkg/logs/tailer_windows.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build windows
 
 package logs

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package metrics
 
 import (

--- a/pkg/metrics/container.go
+++ b/pkg/metrics/container.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package metrics
 
 import (

--- a/pkg/metrics/process.go
+++ b/pkg/metrics/process.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package metrics
 
 import (

--- a/pkg/metrics/request.go
+++ b/pkg/metrics/request.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package metrics
 
 import (

--- a/pkg/metrics/statsd.go
+++ b/pkg/metrics/statsd.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package metrics
 
 import (

--- a/pkg/metrics/system.go
+++ b/pkg/metrics/system.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package metrics
 
 import (

--- a/pkg/profiling/pprof.go
+++ b/pkg/profiling/pprof.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build linux
 
 package profiling

--- a/pkg/profiling/profiler.go
+++ b/pkg/profiling/profiler.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package profiling
 
 import (

--- a/pkg/profiling/profiler_linux.go
+++ b/pkg/profiling/profiler_linux.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build linux
 
 package profiling

--- a/pkg/profiling/profiler_stub.go
+++ b/pkg/profiling/profiler_stub.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build !linux
 
 package profiling

--- a/pkg/profiling/symbols.go
+++ b/pkg/profiling/symbols.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 //go:build linux
 
 package profiling

--- a/pkg/protocol/detect.go
+++ b/pkg/protocol/detect.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/detect_test.go
+++ b/pkg/protocol/detect_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/dns.go
+++ b/pkg/protocol/dns.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/grpc.go
+++ b/pkg/protocol/grpc.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/grpc_test.go
+++ b/pkg/protocol/grpc_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/http.go
+++ b/pkg/protocol/http.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/http_test.go
+++ b/pkg/protocol/http_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/mongodb.go
+++ b/pkg/protocol/mongodb.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/mysql.go
+++ b/pkg/protocol/mysql.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/postgres.go
+++ b/pkg/protocol/postgres.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/postgres_test.go
+++ b/pkg/protocol/postgres_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/redis.go
+++ b/pkg/protocol/redis.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/protocol/redis_test.go
+++ b/pkg/protocol/redis_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package protocol
 
 import (

--- a/pkg/reassembly/request.go
+++ b/pkg/reassembly/request.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package reassembly
 
 import (

--- a/pkg/reassembly/stream.go
+++ b/pkg/reassembly/stream.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package reassembly
 
 import (

--- a/pkg/redact/normalize.go
+++ b/pkg/redact/normalize.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package redact
 
 import (

--- a/pkg/redact/normalize_test.go
+++ b/pkg/redact/normalize_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package redact
 
 import (

--- a/pkg/redact/redactor.go
+++ b/pkg/redact/redactor.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package redact
 
 import (

--- a/pkg/redact/redactor_test.go
+++ b/pkg/redact/redactor_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package redact
 
 import (

--- a/pkg/servicemap/generator.go
+++ b/pkg/servicemap/generator.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package servicemap
 
 import (

--- a/pkg/traces/processor.go
+++ b/pkg/traces/processor.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package traces
 
 import (

--- a/pkg/traces/sampler.go
+++ b/pkg/traces/sampler.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package traces
 
 import (

--- a/pkg/traces/sampler_test.go
+++ b/pkg/traces/sampler_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package traces
 
 import (

--- a/pkg/traces/span.go
+++ b/pkg/traces/span.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package traces
 
 import (

--- a/pkg/traces/stitcher.go
+++ b/pkg/traces/stitcher.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package traces
 
 import (

--- a/pkg/traces/stitcher_test.go
+++ b/pkg/traces/stitcher_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024-2026 Madhukar Beema. All rights reserved.
+// Use of this source code is governed by the Business Source License
+// included in the LICENSE file of this repository.
+
 package traces
 
 import (


### PR DESCRIPTION
All 82 Go source files now carry copyright headers:
  Copyright 2024-2026 Madhukar Beema. All rights reserved.

Licensed under Business Source License 1.1 - source-available, no competitive commercial use for 4 years, then Apache 2.0.